### PR TITLE
Add npm test script and usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ Add to your MCP server list in `mcp_config.json`:
 }
 ```
 
+### Running Tests
+
+After installing dependencies, you can run a simple check to ensure the server
+behaves correctly:
+
+```bash
+npm test
+```
+
+This executes `simple-test.js`, which launches the server and exercises the
+dynamic schema behavior.
+
 `~.~.~.~.~.~.~.~.~.~.~.~.~.~.~.~.~.~.~.~.~.~`
 
 ## 🤔 How It Works

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "LICENSE"
   ],
   "scripts": {
-    "start": "node chucknorris-mcp-server.js"
+    "start": "node chucknorris-mcp-server.js",
+    "test": "node simple-test.js"
   },
   "keywords": [
     "chuck-norris",


### PR DESCRIPTION
## Summary
- define `npm test` script in `package.json`
- describe running the tests in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6863be22cfb8832a90f640d8da299048