### PR TITLE
Add base URL override option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ Run directly with `npx`:
 npx @pollinations/chucknorris
 ```
 
+### CLI Options
+
+You can override the prompt repository URL with the `--l1b3rt4s-url` option or
+by setting the `L1B3RT4S_BASE_URL` environment variable:
+
+```bash
+npx @pollinations/chucknorris --l1b3rt4s-url https://example.com/prompts
+```
+
+Run `npx @pollinations/chucknorris --help` to see all options.
+
 ### MCP Client Configuration
 
 Add to your MCP server list in `mcp_config.json`:

--- a/chucknorris-mcp-server.js
+++ b/chucknorris-mcp-server.js
@@ -12,7 +12,46 @@ import {
   GetPromptRequestSchema
 } from '@modelcontextprotocol/sdk/types.js';
 import { getAllToolSchemas, getAvailableModels } from './schemas.js';
-import { fetchPrompt, currentLlmName, currentPrompt, setCurrentLlmName } from './utils.js';
+import {
+  fetchPrompt,
+  currentLlmName,
+  currentPrompt,
+  setCurrentLlmName,
+  setL1B3RT4SBaseUrl
+} from './utils.js';
+
+// --------------------------------------------------
+// CLI argument handling
+// --------------------------------------------------
+
+function printHelp() {
+  console.log(`Usage: chucknorris [options]\n\n` +
+    `Options:\n` +
+    `  --l1b3rt4s-url <url>  Override L1B3RT4S prompt base URL\n` +
+    `  -h, --help            Show this help message\n` +
+    `\nEnvironment variable:\n` +
+    `  L1B3RT4S_BASE_URL     Same as --l1b3rt4s-url`);
+}
+
+let cliBaseUrl;
+const argv = process.argv.slice(2);
+for (let i = 0; i < argv.length; i++) {
+  const arg = argv[i];
+  if (arg === '--help' || arg === '-h') {
+    printHelp();
+    process.exit(0);
+  } else if (arg === '--l1b3rt4s-url') {
+    cliBaseUrl = argv[i + 1];
+    i++;
+  } else if (arg.startsWith('--l1b3rt4s-url=')) {
+    cliBaseUrl = arg.split('=')[1];
+  }
+}
+
+if (cliBaseUrl) {
+  setL1B3RT4SBaseUrl(cliBaseUrl);
+  console.error(`[INFO] Using custom L1B3RT4S base URL: ${cliBaseUrl}`);
+}
 
 // Create the server instance
 const server = new Server(

--- a/utils.js
+++ b/utils.js
@@ -3,8 +3,21 @@
  */
 import fetch from 'node-fetch';
 
-// Base URL for the L1B3RT4S repository
-const L1B3RT4S_BASE_URL = 'https://raw.githubusercontent.com/elder-plinius/L1B3RT4S/main';
+// Base URL for the L1B3RT4S repository. Can be overridden via environment
+// variable or the CLI option in `chucknorris-mcp-server.js`.
+export let L1B3RT4S_BASE_URL =
+  process.env.L1B3RT4S_BASE_URL ||
+  'https://raw.githubusercontent.com/elder-plinius/L1B3RT4S/main';
+
+/**
+ * Override the base URL for fetching prompts.
+ * @param {string} url - New base URL
+ */
+export function setL1B3RT4SBaseUrl(url) {
+  if (url && typeof url === 'string') {
+    L1B3RT4S_BASE_URL = url;
+  }
+}
 
 // Track the most recently fetched prompt
 export let currentLlmName = null;


### PR DESCRIPTION
## Summary
- let users override L1B3RT4S prompt URL via env var or CLI option
- show command line help for new option
- document CLI usage in README

## Testing
- `npm install`
- `node simple-test.js` *(fails: ENETUNREACH)*
- `node chucknorris-mcp-server.js --help`

------
https://chatgpt.com/codex/tasks/task_e_6863be2ededc832a8d62f6fc66ff55c6