### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,16 @@
+# Code of Conduct
+
+This project adheres to a few simple principles to keep the community welcoming and productive.
+
+## Expectations
+- Be respectful and considerate in all interactions.
+- Avoid harassment, discrimination, or offensive language.
+- Keep discussions focused on improving the project.
+
+## Reporting Issues
+If you witness unacceptable behavior, please open an issue or contact the maintainers at [team@pollinations.ai](mailto:team@pollinations.ai). Reports are treated confidentially and will be reviewed promptly.
+
+## Enforcement
+Project maintainers are responsible for clarifying the standards of acceptable behavior and may take appropriate action in response to any violations.
+
+This policy is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/).

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Want to help? Join via [GitHub Issues](https://github.com/pollinations/model-con
 Part of [Pollinations.AI](https://pollinations.ai).
 - [Discord](https://discord.gg/k9F7SyTgqn)
 - [GitHub Issues](https://github.com/pollinations/model-context-protocol/issues)
+- [Code of Conduct](CODE_OF_CONDUCT.md)
 
 ## 📜 License
 


### PR DESCRIPTION
## Summary
- document expected community behaviour in `CODE_OF_CONDUCT.md`
- mention this policy from README

## Testing
- `npm install`
- `node simple-test.js` *(fails: ENETUNREACH while fetching prompts)*

------
https://chatgpt.com/codex/tasks/task_e_6863be270334832ab388fbe58c5e02da