### PR TITLE
Add offline mode with local prompt support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,21 @@ Run directly with `npx`:
 npx @pollinations/chucknorris
 ```
 
+### Offline Mode
+
+To use local prompt files or run without network access, start the server with
+the `--offline` flag or set the `CHUCKNORRIS_OFFLINE` environment variable:
+
+```bash
+node chucknorris-mcp-server.js --offline
+# or
+CHUCKNORRIS_OFFLINE=1 npx @pollinations/chucknorris
+```
+
+Place your prompt files in a directory (default `./prompts`) and name them
+`<LLM_NAME>.mkd`. You can override the directory with the
+`CHUCKNORRIS_PROMPTS_DIR` environment variable.
+
 ### MCP Client Configuration
 
 Add to your MCP server list in `mcp_config.json`:

--- a/chucknorris-mcp-server.js
+++ b/chucknorris-mcp-server.js
@@ -12,7 +12,14 @@ import {
   GetPromptRequestSchema
 } from '@modelcontextprotocol/sdk/types.js';
 import { getAllToolSchemas, getAvailableModels } from './schemas.js';
-import { fetchPrompt, currentLlmName, currentPrompt, setCurrentLlmName } from './utils.js';
+import {
+  fetchPrompt,
+  currentLlmName,
+  currentPrompt,
+  setCurrentLlmName,
+  OFFLINE_MODE,
+  LOCAL_PROMPTS_DIR
+} from './utils.js';
 
 // Create the server instance
 const server = new Server(
@@ -162,12 +169,15 @@ server.setRequestHandler(GetPromptRequestSchema, async (request) => {
 // Run the server
 async function run() {
   const transport = new StdioServerTransport();
-  
+
   // Import the static model list from schemas.js
   const availableModels = getAvailableModels();
-  
+
   // Log available models
   console.error(`[INFO] Using ${availableModels.length} models from static model list`);
+  if (OFFLINE_MODE) {
+    console.error(`[INFO] Offline mode enabled, loading prompts from ${LOCAL_PROMPTS_DIR}`);
+  }
   
   await server.connect(transport);
   console.error('ChuckNorris MCP server running on stdio');


### PR DESCRIPTION
## Summary
- add offline support in utils with LOCAL_PROMPTS_DIR and OFFLINE_MODE
- fall back to local prompts when network fetch fails
- log offline status in server startup
- document offline mode usage
- include empty prompts directory for local files

## Testing
- `npm install`
- `node simple-test.js` *(fails: ENETUNREACH/ENOENT)*
- `node test-chucknorris-client.js` *(times out)*
- `node test-prompts-api.js` *(fails: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6863bf10a630832aa2134a9f01765c12