### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:18
+WORKDIR /usr/src/app
+COPY package.json ./
+RUN npm install --production
+COPY . .
+CMD ["node", "chucknorris-mcp-server.js"]

--- a/README.md
+++ b/README.md
@@ -79,6 +79,21 @@ npm test
 This executes `simple-test.js`, which launches the server and exercises the
 dynamic schema behavior.
 
+### Docker
+
+Build the container image using the provided Dockerfile:
+
+```bash
+docker build -t chucknorris .
+```
+
+Run the container and communicate via STDIN/STDOUT:
+
+```bash
+docker run -it chucknorris
+```
+
+
 `~.~.~.~.~.~.~.~.~.~.~.~.~.~.~.~.~.~.~.~.~.~`
 
 ## 🤔 How It Works


### PR DESCRIPTION
## Summary
- add a Dockerfile for running the server in a container
- document Docker build and run steps in the README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6863c3e781f8832aa15929f7f74bc208